### PR TITLE
Fixed classnames in container component

### DIFF
--- a/src/components/Container/Container.js
+++ b/src/components/Container/Container.js
@@ -14,8 +14,7 @@ const Container = ({
   const classes = classNames('container', {
     'is-fluid': fluid,
     'has-text-centered': hasTextCentered,
-    className
-  })
+  }, className)
 
   return <div className={classes} {...props} />
 }


### PR DESCRIPTION
className prop was being passed to classNames() improperly 